### PR TITLE
Add downloaded dataset metric

### DIFF
--- a/src/main/java/org/veupathdb/service/dsdl/Metrics.java
+++ b/src/main/java/org/veupathdb/service/dsdl/Metrics.java
@@ -1,0 +1,15 @@
+package org.veupathdb.service.dsdl;
+
+import io.prometheus.client.Counter;
+
+public class Metrics {
+  private static final Counter DOWNLOADS_BY_DATASET = Counter.build()
+      .name("dataset_download")
+      .help("Total successfully uploaded datasets.")
+      .labelNames("dataset_name")
+      .register();
+
+  public static void countDownload(String datasetName) {
+    DOWNLOADS_BY_DATASET.labels(datasetName).inc();
+  }
+}

--- a/src/main/java/org/veupathdb/service/dsdl/Metrics.java
+++ b/src/main/java/org/veupathdb/service/dsdl/Metrics.java
@@ -3,13 +3,13 @@ package org.veupathdb.service.dsdl;
 import io.prometheus.client.Counter;
 
 public class Metrics {
-  private static final Counter DOWNLOADS_BY_DATASET = Counter.build()
+  private static final Counter DOWNLOADS_BY_STUDY_ID = Counter.build()
       .name("dataset_download")
       .help("Total successfully uploaded datasets.")
-      .labelNames("dataset_name")
+      .labelNames("study_id")
       .register();
 
-  public static void countDownload(String datasetName) {
-    DOWNLOADS_BY_DATASET.labels(datasetName).inc();
+  public static void countDownload(String studyId) {
+    DOWNLOADS_BY_STUDY_ID.labels(studyId).inc();
   }
 }

--- a/src/main/java/org/veupathdb/service/dsdl/Service.java
+++ b/src/main/java/org/veupathdb/service/dsdl/Service.java
@@ -65,7 +65,10 @@ public class Service implements Download {
         new MapBuilder<>(HttpHeaders.CONTENT_DISPOSITION, dispositionHeaderValue).toMap());
     return GetDownloadByProjectAndStudyIdAndReleaseAndFileResponse.respond200WithTextPlain(
         new FileContentResponseStream(cSwallow(
-            out -> IoUtil.transferStream(out, Files.newInputStream(filePath)))));
+            out -> {
+              IoUtil.transferStream(out, Files.newInputStream(filePath));
+              Metrics.countDownload(studyId);
+            })));
   }
 
   private String checkPermsAndFetchDatasetHash(String studyId, Function<StudyAccess, Boolean> accessGranter) {


### PR DESCRIPTION
Added a metric for dataset download usage by study ID.

Resolves https://github.com/VEuPathDB/service-dataset-download/issues/5

Tested locally, verified metrics get emitted.