### PR TITLE
Add metrics for download request counts

### DIFF
--- a/src/main/java/org/veupathdb/service/dsdl/Service.java
+++ b/src/main/java/org/veupathdb/service/dsdl/Service.java
@@ -4,6 +4,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.function.Function;
 import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotFoundException;
@@ -59,8 +60,18 @@ public class Service implements Download {
     String datasetHash = checkPermsAndFetchDatasetHash(studyId, StudyAccess::allowResultsAll);
     Path filePath = new FileStore(Resources.getDatasetsParentDir(project))
         .getFilePath(datasetHash, release, fileName)
-        .orElseThrow(NotFoundException::new);
+        .orElseThrow(() -> {
+          LOG.info("Unable to find a file with hash {}, release {}, and name {}.", datasetHash, release, fileName);
+          return new NotFoundException();
+        });
     String dispositionHeaderValue = "attachment; filename=\"" + fileName + "\"";
+    Optional<String> userId = UserProvider.lookupUser(_request)
+        .map(user -> Long.toString(user.getUserID()));
+    ServiceMetrics.downloadReporter()
+        .withStudyName(studyId)
+        .withUserId(userId.orElse("None")) // User ID should always be present, but let's fail open since it's just a metric.
+        .withResourceName(fileName)
+        .report();
     _request.setProperty(CustomResponseHeadersFilter.CUSTOM_HEADERS_KEY,
         new MapBuilder<>(HttpHeaders.CONTENT_DISPOSITION, dispositionHeaderValue).toMap());
     return GetDownloadByProjectAndStudyIdAndReleaseAndFileResponse.respond200WithTextPlain(

--- a/src/main/java/org/veupathdb/service/dsdl/Service.java
+++ b/src/main/java/org/veupathdb/service/dsdl/Service.java
@@ -67,11 +67,7 @@ public class Service implements Download {
     String dispositionHeaderValue = "attachment; filename=\"" + fileName + "\"";
     Optional<String> userId = UserProvider.lookupUser(_request)
         .map(user -> Long.toString(user.getUserID()));
-    ServiceMetrics.downloadReporter()
-        .withStudyName(studyId)
-        .withUserId(userId.orElse("None")) // User ID should always be present, but let's fail open since it's just a metric.
-        .withResourceName(fileName)
-        .report();
+    ServiceMetrics.reportDownloadCount(studyId, userId.orElse("None"), fileName);
     _request.setProperty(CustomResponseHeadersFilter.CUSTOM_HEADERS_KEY,
         new MapBuilder<>(HttpHeaders.CONTENT_DISPOSITION, dispositionHeaderValue).toMap());
     return GetDownloadByProjectAndStudyIdAndReleaseAndFileResponse.respond200WithTextPlain(

--- a/src/main/java/org/veupathdb/service/dsdl/ServiceMetrics.java
+++ b/src/main/java/org/veupathdb/service/dsdl/ServiceMetrics.java
@@ -16,35 +16,7 @@ public class ServiceMetrics {
       .labelNames(STUDY_LABEL, USER_LABEL, RESOURCE_LABEL)
       .register();
 
-  public static DownloadReporter downloadReporter() {
-    return new DownloadReporter();
-  }
-
-  /**
-   * Builder-like interface for reporting download count metrics.
-   */
-  public static class DownloadReporter {
-    private String studyName;
-    private String userId;
-    private String resourceName;
-
-    public DownloadReporter withStudyName(String studyName) {
-      this.studyName = studyName;
-      return this;
-    }
-
-    public DownloadReporter withUserId(String userId) {
-      this.userId = userId;
-      return this;
-    }
-
-    public DownloadReporter withResourceName(String resourceName) {
-      this.resourceName = resourceName;
-      return this;
-    }
-
-    public void report() {
-      STUDY_FILE_DOWNLOAD_METRIC.labels(studyName, userId, resourceName).inc();
-    }
+  public static void reportDownloadCount(String study, String userId, String resourceName) {
+    STUDY_FILE_DOWNLOAD_METRIC.labels(study, userId, resourceName).inc();
   }
 }

--- a/src/main/java/org/veupathdb/service/dsdl/ServiceMetrics.java
+++ b/src/main/java/org/veupathdb/service/dsdl/ServiceMetrics.java
@@ -1,0 +1,50 @@
+package org.veupathdb.service.dsdl;
+
+import io.prometheus.client.Counter;
+
+/**
+ * Utility class for emitting domain-specific service metrics.
+ */
+public class ServiceMetrics {
+  private static final String STUDY_LABEL = "study";
+  private static final String USER_LABEL = "user";
+  private static final String RESOURCE_LABEL = "resource";
+
+  private static final Counter STUDY_FILE_DOWNLOAD_METRIC = Counter.build()
+      .name("dataset_download_requested")
+      .help("Dataset download request count")
+      .labelNames(STUDY_LABEL, USER_LABEL, RESOURCE_LABEL)
+      .register();
+
+  public static DownloadReporter downloadReporter() {
+    return new DownloadReporter();
+  }
+
+  /**
+   * Builder-like interface for reporting download count metrics.
+   */
+  public static class DownloadReporter {
+    private String studyName;
+    private String userId;
+    private String resourceName;
+
+    public DownloadReporter withStudyName(String studyName) {
+      this.studyName = studyName;
+      return this;
+    }
+
+    public DownloadReporter withUserId(String userId) {
+      this.userId = userId;
+      return this;
+    }
+
+    public DownloadReporter withResourceName(String resourceName) {
+      this.resourceName = resourceName;
+      return this;
+    }
+
+    public void report() {
+      STUDY_FILE_DOWNLOAD_METRIC.labels(studyName, userId, resourceName).inc();
+    }
+  }
+}


### PR DESCRIPTION
## Overview
Adding metric for download request count. These metrics will be scraped to generate tab-file reports for ClinEpi outreach. Due to the relatively high cardinality of the data, it may be slightly less useful to visualize in Grafana. The level of label granularity is needed however to produce the required metrics.

## Testing
* Ran locally and verified metrics are emitted